### PR TITLE
Address linting issues reported by Mixtool

### DIFF
--- a/alerts/coredns.libsonnet
+++ b/alerts/coredns.libsonnet
@@ -18,7 +18,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has disappeared from Prometheus target discovery.',
+              summary: 'CoreDNS has disappeared from Prometheus target discovery.',
+              description: 'CoreDNS has disappeared from Prometheus target discovery.',
             },
           },
           {
@@ -31,7 +32,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has 99th percentile latency of {{ $value }} seconds for server {{ $labels.server }} zone {{ $labels.zone }} .',
+              summary: 'CoreDNS is experiencing high 99th percentile latency.',
+              description: 'CoreDNS has 99th percentile latency of {{ $value }} seconds for server {{ $labels.server }} zone {{ $labels.zone }} .',
             },
           },
           {
@@ -46,7 +48,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
+              summary: 'CoreDNS is returning SERVFAIL.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
             },
           },
           {
@@ -61,7 +64,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
+              summary: 'CoreDNS is returning SERVFAIL.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests.',
             },
           },
         ],

--- a/alerts/forward.libsonnet
+++ b/alerts/forward.libsonnet
@@ -18,7 +18,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS has 99th percentile latency of {{ $value }} seconds forwarding requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is experiencing high latency forwarding requests.',
+              description: 'CoreDNS has 99th percentile latency of {{ $value }} seconds forwarding requests to {{ $labels.to }}.',
             },
           },
           {
@@ -33,7 +34,8 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is returning SERVFAIL for forward requests.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
             },
           },
           {
@@ -48,7 +50,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
+              summary: 'CoreDNS is returning SERVFAIL for forward requests.',
+              description: 'CoreDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}.',
             },
           },
           {
@@ -61,7 +64,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS health checks have failed to upstream server {{ $labels.to }}.',
+              summary: 'CoreDNS health checks have failed to upstream server.',
+              description: 'CoreDNS health checks have failed to upstream server {{ $labels.to }}.',
             },
           },
           {
@@ -74,7 +78,8 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'CoreDNS health checks have failed for all upstream servers.',
+              summary: 'CoreDNS health checks have for all upstream servers.',
+              description: 'CoreDNS health checks have failed for all upstream servers.',
             },
           },
         ],

--- a/dashboards/coredns.libsonnet
+++ b/dashboards/coredns.libsonnet
@@ -8,7 +8,7 @@ local singlestat = grafana.singlestat;
 
 {
   _config+:: {
-    corednsSelector: 'job="kube-dns"',
+    corednsSelector: 'job=~"kube-dns"',
   },
 
   grafanaDashboards+:: {
@@ -216,8 +216,11 @@ local singlestat = grafana.singlestat;
           'instance',
           '$datasource',
           'label_values(coredns_build_info{%(corednsSelector)s}, %(instanceLabel)s)' % $._config,
-          refresh='time',
+          label='instance',
+          refresh='load',
+          multi=true,
           includeAll=true,
+          allValues='.+',
           sort=1,
         )
       ).addRow(


### PR DESCRIPTION
This PR introduces fixes to linting conflicts:
- Alerts now have summaries, without any templated values
- Alerts now have descriptions with templated values, where appropriate
- Dashboard `instance` template now has correct `instance` label
- Dashboard `job` query now correctly uses `job=~""`