### PR TITLE
Update coredns alerts

### DIFF
--- a/alerts/coredns.libsonnet
+++ b/alerts/coredns.libsonnet
@@ -25,7 +25,7 @@
           {
             alert: 'CoreDNSLatencyHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) by(server, zone, le)) > %(corednsLatencyCriticalSeconds)s
+              histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) without (instance,pod)) > %(corednsLatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -39,9 +39,9 @@
           {
             alert: 'CoreDNSErrorsHigh',
             expr: |||
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.03
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.03
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -55,9 +55,9 @@
           {
             alert: 'CoreDNSErrorsHigh',
             expr: |||
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.01
+              sum without (pod, instance, server, zone, view, rcode, plugin) (rate(coredns_dns_responses_total{%(corednsSelector)s}[5m])) > 0.01
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/alerts/forward.libsonnet
+++ b/alerts/forward.libsonnet
@@ -11,7 +11,7 @@
           {
             alert: 'CoreDNSForwardLatencyHigh',
             expr: |||
-              histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) by(to, le)) > %(corednsForwardLatencyCriticalSeconds)s
+              histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{%(corednsSelector)s}[5m])) without (pod, instance, rcode)) > %(corednsForwardLatencyCriticalSeconds)s
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -25,9 +25,9 @@
           {
             alert: 'CoreDNSForwardErrorsHigh',
             expr: |||
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.03
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.03
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -41,9 +41,9 @@
           {
             alert: 'CoreDNSForwardErrorsHigh',
             expr: |||
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s,rcode="SERVFAIL"}[5m]))
                 /
-              sum(rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.01
+              sum without (pod, instance, rcode) (rate(coredns_forward_responses_total{%(corednsSelector)s}[5m])) > 0.01
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -57,7 +57,7 @@
           {
             alert: 'CoreDNSForwardHealthcheckFailureCount',
             expr: |||
-              sum(rate(coredns_forward_healthcheck_failures_total{%(corednsSelector)s}[5m])) by (to) > 0
+              sum without (pod, instance) (rate(coredns_forward_healthcheck_failures_total{%(corednsSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -71,14 +71,14 @@
           {
             alert: 'CoreDNSForwardHealthcheckBrokenCount',
             expr: |||
-              sum(rate(coredns_forward_healthcheck_broken_total{%(corednsSelector)s}[5m])) > 0
+              sum without (pod, instance) (rate(coredns_forward_healthcheck_broken_total{%(corednsSelector)s}[5m])) > 0
             ||| % $._config,
             'for': '10m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              summary: 'CoreDNS health checks have for all upstream servers.',
+              summary: 'CoreDNS health checks have failed for all upstream servers.',
               description: 'CoreDNS health checks have failed for all upstream servers.',
             },
           },


### PR DESCRIPTION
Flip by() to without() to keep possible custom/external labels in alerts for routing/descriptions

Aggregation happens without
metrics built-in labels (https://coredns.io/plugins/metrics/#description) and instance,pod dimentions. If compared side-by-side, aggregation results of by() and without() are identical but without() has all possible custom labels in place.

One more example here: https://promlabs.com/blog/2022/12/11/avoid-these-6-mistakes-when-getting-started-with-prometheus/#mistake-2-aggregating-away-valuable-labels-in-alerting-expressions