### PR TITLE
Add multicluster support to mixin for k8s support

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,7 +1,7 @@
 {
   _config+:: {
     enableMultiCluster: false,
-    corednsSelector: if self.enableMultiCluster then  'job=~"kube-dns", cluster=~"$cluster"' else 'job=~"kube-dns"',
+    corednsSelector: if self.enableMultiCluster then 'job=~"kube-dns", cluster=~"$cluster"' else 'job=~"kube-dns"',
     multiclusterSelector: 'job=~"kube-dns"',
     instanceLabel: 'pod',
 

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -1,6 +1,8 @@
 {
   _config+:: {
-    corednsSelector: 'job="kube-dns"',
+    enableMultiCluster: false,
+    corednsSelector: if self.enableMultiCluster then  'job=~"kube-dns", cluster=~"$cluster"' else 'job=~"kube-dns"',
+    multiclusterSelector: 'job=~"kube-dns"',
     instanceLabel: 'pod',
 
     grafanaDashboardIDs+: {

--- a/dashboards/coredns.libsonnet
+++ b/dashboards/coredns.libsonnet
@@ -213,6 +213,16 @@ local singlestat = grafana.singlestat;
         },
       ).addTemplate(
         template.new(
+          'cluster',
+          '$datasource',
+          'label_values(coredns_build_info{%(multiclusterSelector)s}, cluster)' % $._config,
+          label='cluster',
+          refresh='load',
+          hide=if $._config.enableMultiCluster then '' else 'variable',
+          sort=1,
+        )
+      ).addTemplate(
+        template.new(
           'instance',
           '$datasource',
           'label_values(coredns_build_info{%(corednsSelector)s}, %(instanceLabel)s)' % $._config,

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -4,8 +4,17 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib",
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
           "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs.git",
+          "subdir": "grafana-builder"
         }
       },
       "version": "master"

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -4,17 +4,8 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib.git",
+          "remote": "https://github.com/grafana/grafonnet-lib",
           "subdir": "grafonnet"
-        }
-      },
-      "version": "master"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/grafana/jsonnet-libs.git",
-          "subdir": "grafana-builder"
         }
       },
       "version": "master"


### PR DESCRIPTION
Adds a multicluster enable/disable option for k8s support in the config file with corresponding changes in the dashboard.